### PR TITLE
修正 SceneNode::SetRenderingOrder 带来的性能影响

### DIFF
--- a/got2d/include/g2dscene.h
+++ b/got2d/include/g2dscene.h
@@ -150,7 +150,6 @@ namespace g2d
 	class G2DAPI Entity : public GObject, public EventReceiver
 	{
 		SceneNode* m_sceneNode = nullptr;
-		uint32_t m_renderingOrder = 0;
 	public:
 		// 用户自定义实体需要实现内存释放的接口
 		// 引擎内部会调用这个接口释放entity资源
@@ -176,12 +175,6 @@ namespace g2d
 		// 初始化场景节点的时候
 		// 设置关联
 		void SetSceneNode(g2d::SceneNode* node);
-
-		// 根据场景节点关系调整渲染顺序
-		// 用于渲染排序，在此只做记录使用
-		void SetRenderingOrder(uint32_t order);
-
-		uint32_t GetRenderingOrder() const { return m_renderingOrder; }
 	};
 
 	// 一张图片
@@ -316,7 +309,7 @@ namespace g2d
 
 		// 移除确定组件，并且强制不调用Release接口
 		virtual bool RemoveComponentWithoutReleased(Component*) = 0;
-		
+
 		// 获取某个组件的释放条件，如果组件不存在，返回假。
 		virtual bool IsComponentAutoRelease(Component*) const = 0;
 
@@ -377,7 +370,7 @@ namespace g2d
 
 		// 获取节点绑定的Entity对象
 		virtual Entity* GetEntity() const = 0;
-		
+
 		// 获取当前节点是父亲的第几个节点
 		virtual uint32_t GetChildIndex() const = 0;
 
@@ -395,6 +388,9 @@ namespace g2d
 
 		// 把坐标转换节点同级的局部空间
 		virtual gml::vec2 WorldToParent(const gml::vec2& pos) = 0;
+
+		// 供内部使用，获得当前的渲染顺序，用于排序
+		virtual uint32_t GetRenderingOrder() const = 0;
 	};
 
 	// 根据类型获取

--- a/got2d/source/entity.cpp
+++ b/got2d/source/entity.cpp
@@ -22,11 +22,6 @@ void g2d::Entity::SetSceneNode(g2d::SceneNode* node)
 	m_sceneNode = node;
 }
 
-void g2d::Entity::SetRenderingOrder(uint32_t order)
-{
-	m_renderingOrder = order;
-}
-
 uint32_t g2d::Entity::GetVisibleMask() const
 {
 	return GetSceneNode()->GetVisibleMask();

--- a/got2d/source/input.h
+++ b/got2d/source/input.h
@@ -5,7 +5,7 @@
 #include <map>
 #include <vector>
 
-constexpr uint32_t PRESSING_INTERVAL = 700u;
+constexpr uint32_t PRESSING_INTERVAL = 500u;
 
 //用户填充这个收听键盘消息
 struct KeyEventReceiver

--- a/got2d/source/scene.h
+++ b/got2d/source/scene.h
@@ -232,7 +232,7 @@ public:
 public:	//g2d::SceneNode
 	virtual g2d::Scene* GetScene() const override;
 
-	virtual g2d::SceneNode* GetParentNode() const override;
+	virtual g2d::SceneNode* GetParentNode() const override { return &m_iparent; }
 
 	virtual g2d::SceneNode* GetPrevSiblingNode() const override { return GetPrevSibling(); }
 
@@ -336,6 +336,7 @@ private:
 	uint32_t m_renderingOrder = 0xFFFFFFFF;//保证一开始是错误的
 	::Scene& m_scene;
 	::BaseNode& m_bparent;
+	g2d::SceneNode& m_iparent;
 	::SceneNode* m_parent = nullptr;
 	g2d::Entity* m_entity = nullptr;
 	bool m_autoRelease = false;

--- a/got2d/source/scene_node.cpp
+++ b/got2d/source/scene_node.cpp
@@ -4,6 +4,7 @@
 SceneNode::SceneNode(::Scene& scene, ::SceneNode* parent, uint32_t childID, g2d::Entity* entity, bool autoRelease)
 	: m_scene(scene)
 	, m_parent(parent)
+	, m_iparent(*parent)
 	, m_bparent(*parent)
 	, m_entity(entity)
 	, m_childIndex(childID)
@@ -16,6 +17,7 @@ SceneNode::SceneNode(::Scene& scene, ::SceneNode* parent, uint32_t childID, g2d:
 
 SceneNode::SceneNode(::Scene& scene, uint32_t childID, g2d::Entity* entity, bool autoRelease)
 	: m_scene(scene)
+	, m_iparent(scene)
 	, m_parent(nullptr)
 	, m_bparent(scene)
 	, m_entity(entity)
@@ -41,24 +43,11 @@ g2d::Scene* SceneNode::GetScene() const
 	return &m_scene;
 }
 
-g2d::SceneNode * SceneNode::GetParentNode() const
-{
-	if (ParentIsScene())
-	{
-		g2d::SceneNode* node = GetScene();
-		return node;
-	}
-	else
-	{
-		return m_parent;
-	}
-}
-
 const gml::mat32& SceneNode::GetWorldMatrix()
 {
 	if (m_matrixWorldDirty)
 	{
-		auto& matParent = GetParentNode()->GetWorldMatrix();
+		auto& matParent = m_iparent.GetWorldMatrix();
 		m_matrixWorld = matParent * GetLocalMatrix();
 		m_matrixWorldDirty = false;
 	}
@@ -246,7 +235,7 @@ gml::vec2 SceneNode::WorldToLocal(const gml::vec2& pos)
 
 gml::vec2 SceneNode::WorldToParent(const gml::vec2& pos)
 {
-	gml::mat33 worldMatrixInv = gml::mat33(GetParentNode()->GetWorldMatrix()).inversed();
+	gml::mat33 worldMatrixInv = gml::mat33(m_iparent.GetWorldMatrix()).inversed();
 	auto p = gml::transform_point(worldMatrixInv, pos);
 	return p;
 }


### PR DESCRIPTION
closes #65 
之前是只要场景树变化，没变化一次就递归调整一次渲染顺序Cache。
导致大量创建的时候非常慢，现在是无论创建多少次，只在场景中标记一下场景树变了。
每次渲染之前，做一次有限的顺序调整。